### PR TITLE
Add composer autoload support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,11 +1,14 @@
 {
     "name": "simplepush/simplepush-php",
     "type": "library",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "description": "Send push notifications to your smartphone with simplepush.io",
     "keywords": ["notification","android", "push", "simplepush", "app"],
     "homepage": "https://simplepush.io",
     "require": {
-	"php": ">=5.3.0"
+        "php": ">=5.3.0"
+    },
+    "autoload": {
+        "classmap": ["src/Simplepush/Simplepush-PHP/Simplepush.php"]
     }
 }


### PR DESCRIPTION
While trying to use the package as indicated in the "Libraries - PHP" section on https://simplepush.io/, I got error messages, the class "Simplepush" could not be found. By adding a classmap autoload instruction to the composer.json file, this can be fixed without having to add a namespace, therefore without breaking backwards compatibility.

I also bumped the version to 1.0.2 so that composer would download the version from my forked repo while I was checking to see if this works, not the version from packagist.